### PR TITLE
Fine-tuning article titles in citations in JOSS paper

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -16,7 +16,7 @@
 
 @ARTICLE{starredscience,
        author = {{Millon}, Martin and {Michalewicz}, Kevin and {Dux}, Fr{\'e}d{\'e}ric and {Courbin}, Fr{\'e}d{\'e}ric and {Marshall}, Philip J.},
-        title = "{Image Deconvolution and Point-spread Function Reconstruction with STARRED: A Wavelet-based Two-channel Method Optimized for Light-curve Extraction}",
+        title = {Image Deconvolution and Point-spread Function Reconstruction with {STARRED}: A Wavelet-based Two-channel Method Optimized for Light-curve Extraction},
       journal = {The Astronomical Journal},
      keywords = {Deconvolution, Photometry, Light curves, Astronomy image processing, 1910, 1234, 918, 2306, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Astrophysics of Galaxies},
          year = 2024,
@@ -59,7 +59,7 @@ archivePrefix = {arXiv},
 	month = {mar 18},
 	note = {https://baas.aas.org/pub/2021n4i236},
 	publisher = {},
-	title = {The {Scientific} {Impact} of the {Vera} {C}. {Rubin} {Observatory}\textquoteright{}s {Legacy} {Survey} of {Space} and {Time} ({LSST}) for {Solar} {System} {Science}},
+	title = {The Scientific Impact of the {Vera} {C}. {Rubin} {Observatory}\textquoteright{}s {Legacy} {Survey} of {Space} and {Time} ({LSST}) for Solar System Science},
 	volume = {53},
 }
 
@@ -122,7 +122,7 @@ archivePrefix = {arXiv},
          {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and
          {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and
          {Zabalza}, V. and {Astropy Contributors}},
-        title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
+        title = {The {A}stropy {P}roject: Building an Open-science Project and Status of the v2.0 Core Package},
       journal = {The Astronomical Journal},
      keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
          year = 2018,
@@ -141,7 +141,7 @@ archivePrefix = {arXiv},
 
 @article{astropy_2022,
        author = {{Astropy Collaboration} and {Price-Whelan}, Adrian M. and {Lim}, Pey Lian and {Earl}, Nicholas and {Starkman}, Nathaniel and {Bradley}, Larry and {Shupe}, David L. and {Patil}, Aarya A. and {Corrales}, Lia and {Brasseur}, C.~E. and {N{"o}the}, Maximilian and {Donath}, Axel and {Tollerud}, Erik and {Morris}, Brett M. and {Ginsburg}, Adam and {Vaher}, Eero and {Weaver}, Benjamin A. and {Tocknell}, James and {Jamieson}, William and {van Kerkwijk}, Marten H. and {Robitaille}, Thomas P. and {Merry}, Bruce and {Bachetti}, Matteo and {G{"u}nther}, H. Moritz and {Aldcroft}, Thomas L. and {Alvarado-Montes}, Jaime A. and {Archibald}, Anne M. and {B{'o}di}, Attila and {Bapat}, Shreyas and {Barentsen}, Geert and {Baz{'a}n}, Juanjo and {Biswas}, Manish and {Boquien}, M{'e}d{'e}ric and {Burke}, D.~J. and {Cara}, Daria and {Cara}, Mihai and {Conroy}, Kyle E. and {Conseil}, Simon and {Craig}, Matthew W. and {Cross}, Robert M. and {Cruz}, Kelle L. and {D'Eugenio}, Francesco and {Dencheva}, Nadia and {Devillepoix}, Hadrien A.~R. and {Dietrich}, J{"o}rg P. and {Eigenbrot}, Arthur Davis and {Erben}, Thomas and {Ferreira}, Leonardo and {Foreman-Mackey}, Daniel and {Fox}, Ryan and {Freij}, Nabil and {Garg}, Suyog and {Geda}, Robel and {Glattly}, Lauren and {Gondhalekar}, Yash and {Gordon}, Karl D. and {Grant}, David and {Greenfield}, Perry and {Groener}, Austen M. and {Guest}, Steve and {Gurovich}, Sebastian and {Handberg}, Rasmus and {Hart}, Akeem and {Hatfield-Dodds}, Zac and {Homeier}, Derek and {Hosseinzadeh}, Griffin and {Jenness}, Tim and {Jones}, Craig K. and {Joseph}, Prajwel and {Kalmbach}, J. Bryce and {Karamehmetoglu}, Emir and {Ka{l}uszy{'n}ski}, Miko{l}aj and {Kelley}, Michael S.~P. and {Kern}, Nicholas and {Kerzendorf}, Wolfgang E. and {Koch}, Eric W. and {Kulumani}, Shankar and {Lee}, Antony and {Ly}, Chun and {Ma}, Zhiyuan and {MacBride}, Conor and {Maljaars}, Jakob M. and {Muna}, Demitri and {Murphy}, N.~A. and {Norman}, Henrik and {O'Steen}, Richard and {Oman}, Kyle A. and {Pacifici}, Camilla and {Pascual}, Sergio and {Pascual-Granado}, J. and {Patil}, Rohit R. and {Perren}, Gabriel I. and {Pickering}, Timothy E. and {Rastogi}, Tanuj and {Roulston}, Benjamin R. and {Ryan}, Daniel F. and {Rykoff}, Eli S. and {Sabater}, Jose and {Sakurikar}, Parikshit and {Salgado}, Jes{'u}s and {Sanghi}, Aniket and {Saunders}, Nicholas and {Savchenko}, Volodymyr and {Schwardt}, Ludwig and {Seifert-Eckert}, Michael and {Shih}, Albert Y. and {Jain}, Anany Shrey and {Shukla}, Gyanendra and {Sick}, Jonathan and {Simpson}, Chris and {Singanamalla}, Sudheesh and {Singer}, Leo P. and {Singhal}, Jaladh and {Sinha}, Manodeep and {Sip{H{o}}cz}, Brigitta M. and {Spitler}, Lee R. and {Stansby}, David and {Streicher}, Ole and {{␋{S}}umak}, Jani and {Swinbank}, John D. and {Taranu}, Dan S. and {Tewary}, Nikita and {Tremblay}, Grant R. and {Val-Borro}, Miguel de and {Van Kooten}, Samuel J. and {Vasovi{'c}}, Zlatan and {Verma}, Shresth and {de Miranda Cardoso}, Jos{'e} Vin{'i}cius and {Williams}, Peter K.~G. and {Wilson}, Tom J. and {Winkel}, Benjamin and {Wood-Vasey}, W.~M. and {Xue}, Rui and {Yoachim}, Peter and {Zhang}, Chen and {Zonca}, Andrea and {Astropy Project Contributors}},
-        title = "{The Astropy Project: Sustaining and Growing a Community-oriented Open-source Project and the Latest Major Release (v5.0) of the Core Package}",
+        title = {The {A}stropy {P}roject: Sustaining and Growing a Community-oriented Open-source Project and the Latest Major Release (v5.0) of the Core Package},
       journal = {The Astrophysical Journal},
      keywords = {Astronomy software, Open source software, Astronomy data analysis, 1855, 1866, 1858, Astrophysics - Instrumentation and Methods for Astrophysics},
          year = 2022,
@@ -178,7 +178,7 @@ archivePrefix = {arXiv},
 
 @article{astrometry,
        author = {{Lang}, Dustin and {Hogg}, David W. and {Mierle}, Keir and {Blanton}, Michael and {Roweis}, Sam},
-        title = "{Astrometry.net: Blind Astrometric Calibration of Arbitrary Astronomical Images}",
+        title = {Astrometry.net: Blind Astrometric Calibration of Arbitrary Astronomical Images},
       journal = {The Astronomical Journal},
      keywords = {astrometry, catalogs, instrumentation: miscellaneous, methods: data analysis, methods: statistical, techniques: image processing, Astrophysics - Instrumentation and Methods for Astrophysics},
          year = 2010,
@@ -216,7 +216,7 @@ archivePrefix = {arXiv},
 
 @ARTICLE{lacosmic,
        author = {{van Dokkum}, Pieter G.},
-        title = "{Cosmic-Ray Rejection by Laplacian Edge Detection}",
+        title = {Cosmic-Ray Rejection by {Laplacian} Edge Detection},
       journal = {Publications of the Astronomical Society of the Pacific},
      keywords = {Instrumentation: Detectors, Methods: Data Analysis-techniques: image processing, Astrophysics},
          year = 2001,
@@ -266,7 +266,7 @@ archivePrefix = {arXiv},
 	{de Val-Borro}, M. and {Valtchanov}, I. and {Woillez}, J. and
 	{The Astroquery collaboration} and {a subset of the astropy collaboration}
 	},
-    title = "{astroquery: An Astronomical Web-querying Package in Python}",
+    title = {astroquery: An Astronomical Web-querying Package in {P}ython},
   journal = {The Astronomical Journal},
 archivePrefix = "arXiv",
    eprint = {1901.04520},
@@ -313,7 +313,7 @@ volume = {494},
 number = {1},
 pages = {472--477},
 author = {P. Magain and F. Courbin and S. Sohy},
-title = "{Deconvolution with Correct Sampling}",
+title = {Deconvolution with Correct Sampling},
 journal = {The Astrophysical Journal},
 abstract = {A new method for improving the resolution of astronomical images is presented. It is based on the principle that sampled data cannot be fully deconvolved without violating the sampling theorem. Thus, the sampled image should be deconvolved not by the total point-spread function but by a narrower function chosen so that the resolution of the deconvolved image is compatible with the adopted sampling. Our deconvolution method gives results that are, in at least some cases, superior to those of other commonly used techniques: in particular, it does not produce ringing around point sources superposed on a smooth background. Moreover, it allows researchers to perform accurate astrometry and photometry of crowded fields. These improvements are a consequence of both the correct treatment of sampling and the recognition that the most probable astronomical image is not a flat one. The method is also well adapted to the optimal combination of different images of the same object, as can be obtained, e.g., from infrared observations or via adaptive optics techniques.}
 }
@@ -347,7 +347,7 @@ abstract = {A new method for improving the resolution of astronomical images is 
 
 @software{pyephem,
        author = {{Rhodes}, Brandon Craig},
-        title = "{PyEphem: Astronomical Ephemeris for Python}",
+        title = {{PyEphem}: Astronomical Ephemeris for {P}ython},
  howpublished = {Astrophysics Source Code Library, record ascl:1112.014},
          year = 2011,
         month = dec,
@@ -408,8 +408,8 @@ abstract = {A new method for improving the resolution of astronomical images is 
             Harris, Charles R. and Archibald, Anne M. and
             Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and
             {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
-  title   = {{{SciPy} 1.0: Fundamental Algorithms for Scientific
-            Computing in Python}},
+  title   = {{SciPy} 1.0: Fundamental Algorithms for Scientific
+            Computing in Python},
   journal = {Nature Methods},
   year    = {2020},
   volume  = {17},
@@ -420,7 +420,7 @@ abstract = {A new method for improving the resolution of astronomical images is 
 
 @software{reback2020pandas,
     author       = {development team pandas},
-    title        = {pandas-dev/pandas: Pandas},
+    title        = "{pandas-dev/pandas: Pandas}",
     month        = feb,
     year         = 2020,
     publisher    = {Zenodo},
@@ -431,7 +431,7 @@ abstract = {A new method for improving the resolution of astronomical images is 
 
 @InProceedings{ mckinney-proc-scipy-2010,
   author    = { {W}es {M}c{K}inney },
-  title     = { {D}ata {S}tructures for {S}tatistical {C}omputing in {P}ython },
+  title     = { {D}ata Structures for Statistical Computing in {P}ython },
   booktitle = { {P}roceedings of the 9th {P}ython in {S}cience {C}onference },
   pages     = { 56 - 61 },
   year      = { 2010 },
@@ -443,7 +443,7 @@ abstract = {A new method for improving the resolution of astronomical images is 
   doi = {10.5281/zenodo.596036},
   url = {https://zenodo.org/doi/10.5281/zenodo.596036},
   author = {Larry Bradley,   and Brigitta Sipőcz,   and Thomas Robitaille,   and Erik Tollerud,   and Zé Vinícius,   and Christoph Deil,   and Kyle Barbary,   and Tom J Wilson,   and Ivo Busko,   and Axel Donath,   and Hans Moritz G\"{u}nther,   and Mihai Cara,   and P. L. Lim,   and Sebastian Meßlinger,   and Zach Burnett,   and Simon Conseil,   and Michael Droettboom,   and Azalee Bostroem,   and E. M. Bray,   and Lars Andersen Bratholm,   and William Jamieson,   and Adam Ginsburg,   and Geert Barentsen,   and Matt Craig,   and Sergio Pascual,   and Shivangee Rathi,   and Marshall Perrin,   and Brett M. Morris,   and Gabriel Perren,  },
-  title = {astropy/photutils: 1.12.0},
+  title = "{astropy/photutils: 1.12.0}",
   publisher = {Zenodo},
   year = {2024},
   copyright = {Creative Commons Attribution 4.0 International}


### PR DESCRIPTION
Some final tweaks to the appearance of article titles in the reference list for the [JOSS review](https://github.com/openjournals/joss-reviews/issues/6775). I acknowledge that some of these revert changes in my previous PR but this is the outcome of a more consistent sweep.